### PR TITLE
Adding support for "mask_required" tag on event cards/content

### DIFF
--- a/src/app/Events/EventCard.tsx
+++ b/src/app/Events/EventCard.tsx
@@ -59,6 +59,7 @@ export const EventCard: FC<EventCardProps> = ({ type = "duration", event, onPres
 
     return (
         <EventCardContent
+            badges={event.Badges}
             glyph={event.Glyph}
             pre={pre}
             poster={event.BannerImageUrl ? { uri: event.BannerImageUrl } : undefined}

--- a/src/app/Events/EventCardContent.tsx
+++ b/src/app/Events/EventCardContent.tsx
@@ -9,8 +9,10 @@ import { IconNames } from "../../types/IconNames";
 import { appStyles } from "../AppStyles";
 
 const glyphIconSize = 90;
+const badgeIconSize = 20;
 
 export type EventCardProps = {
+    badges?: IconNames[];
     glyph?: IconNames;
     pre: ReactNode;
     poster?: ImageSourcePropType;
@@ -23,10 +25,12 @@ export type EventCardProps = {
     onLongPress?: () => void;
 };
 
-export const EventCardContent: FC<EventCardProps> = memo(({ glyph, pre, poster, title, subtitle, tag, happening, done, onPress, onLongPress }) => {
+export const EventCardContent: FC<EventCardProps> = memo(({ badges, glyph, pre, poster, title, subtitle, tag, happening, done, onPress, onLongPress }) => {
     const theme = useTheme();
     const styleContainer = useMemo<ViewStyle>(() => ({ backgroundColor: theme.background }), [theme]);
     const stylePre = useMemo<ViewStyle>(() => ({ backgroundColor: done ? theme.darken : theme.primary }), [done, theme]);
+    const styleBadgeFrame = useMemo<ViewStyle>(() => ({ backgroundColor : theme.secondary }),  [theme]);
+    const colorBadge = useMemo<ColorValue>(() => (theme.white),  [theme]);
     const colorGlyph = useMemo<ColorValue>(() => (done ? theme.darken : theme.white), [done, theme]);
     return (
         <TouchableOpacity style={[styles.container, appStyles.shadow, styleContainer]} onPress={onPress} onLongPress={onLongPress}>
@@ -63,6 +67,16 @@ export const EventCardContent: FC<EventCardProps> = memo(({ glyph, pre, poster, 
                 </View>
             )}
 
+            {!badges ? null : (
+                <View style={styles.badgeContainer}>
+                    {badges.map((icon) => (
+                        <View style={[styles.badgeFrame, styleBadgeFrame]}>
+                            <Icon name={icon} color={colorBadge} size={badgeIconSize} />
+                        </View>
+                    ))}
+                </View>
+            )}        
+
             {!happening ? null : (
                 <View style={styles.indicator}>
                     <Indicator color={done ? theme.important : theme.invText} />
@@ -92,6 +106,18 @@ const styles = StyleSheet.create({
     glyph: {
         opacity: 0.2,
         transform: [{ rotate: "-15deg" }],
+    },
+    badgeContainer: {
+        position: "absolute",
+        top: 0,
+        right: 0,
+        flexDirection: "row",
+    },
+    badgeFrame: {
+        borderRadius: 16,
+        flex: 1,
+        padding: 4,
+        margin: 8,
     },
     pre: {
         overflow: "hidden",

--- a/src/app/Events/EventContent.tsx
+++ b/src/app/Events/EventContent.tsx
@@ -69,10 +69,17 @@ export const EventContent: FC<EventContentProps> = ({ event, parentPad = 0 }) =>
                 </BadgeInvPad>
             )}
 
+           
             <Section icon={isFavorited ? "heart" : event.Glyph} title={event.Title ?? ""} subtitle={event.SubTitle} />
             <Label type="para" mb={20}>
                 {event.Abstract}
             </Label>
+            
+            {!event.MaskRequired ? null : (
+                <Label type="para" icon="face-mask" mb={20} color={theme.secondary}>
+                    {t("mask_required")}
+                </Label>
+            )}
 
             <Row>
                 <Button style={styles.rowLeft} outline={isFavorited} icon={isFavorited ? "heart-outline" : "heart"} onPress={toggleReminder}>

--- a/src/components/Atoms/Label.tsx
+++ b/src/components/Atoms/Label.tsx
@@ -1,6 +1,9 @@
 import { FC, useMemo } from "react";
 import { ColorValue, StyleProp, StyleSheet, Text, TextProps, TextStyle } from "react-native";
 
+import Icon from "@expo/vector-icons/MaterialCommunityIcons";
+import { IconNames } from "../../types/IconNames";
+
 import { Theme, useTheme } from "../../context/Theme";
 
 /**
@@ -20,6 +23,11 @@ export type LabelProps = TextProps & {
      * The color name, a value from the theme.
      */
     color?: keyof Theme | ColorValue;
+
+    /**
+     * The icon to be displayed next to the label.
+     */
+    icon?: IconNames;
 
     /**
      * Margin left.
@@ -42,7 +50,7 @@ export type LabelProps = TextProps & {
     mb?: number;
 };
 
-export const Label: FC<LabelProps> = ({ style, type, variant, color = "text", ml, mt, mr, mb, children, ...props }) => {
+export const Label: FC<LabelProps> = ({ style, type, variant, color = "text", icon, ml, mt, mr, mb, children, ...props }) => {
     // Get theme for resolution.
     const theme = useTheme();
 
@@ -59,10 +67,14 @@ export const Label: FC<LabelProps> = ({ style, type, variant, color = "text", ml
         if (typeof mb === "number") result.marginBottom = mb;
         return result;
     }, [ml, mt, mr, mb, theme, color]);
+    
+    const iconStyle: StyleProp<TextStyle> = { marginRight: 8, textAlignVertical: "bottom" };
+    const iconSize = StyleSheet.flatten(resType).fontSize * 2;
 
     // Return styled text.
     return (
         <Text style={[resType, resVariant, marginColor, style]} {...props}>
+            {!icon ? null : (<Icon name={icon} style={iconStyle} size={iconSize} />)}
             {children}
         </Text>
     );

--- a/src/i18n/translations.en.json
+++ b/src/i18n/translations.en.json
@@ -54,6 +54,7 @@
   "Event": {
     "supersponsor_event":"Supersponsor event",
     "sponsor_event":"Sponsor event",
+    "mask_required": "Face masks are mandatory for this event",
     "view_on_map": "View on map",
     "when": "{{day}}, {{start}} until {{finish}}."
   },

--- a/src/store/eurofurence.enrichers.ts
+++ b/src/store/eurofurence.enrichers.ts
@@ -62,9 +62,19 @@ const tagsToIcon = (tags?: string[]): IconNames | undefined => {
     if (tags.includes("photoshoot")) return "camera";
 };
 
+const tagsToBadges = (tags?: string[]) : IconNames[] | undefined => {
+    if (!tags) return [];
+
+    let badges: Array<IconNames> =[];
+    if (tags.includes("mask_required")) badges.push("face-mask");
+    return badges;
+};
+
 const superSponsorOnly = (tags?: string[]) => Boolean(tags?.includes("supersponsors_only"));
 
 const sponsorOnly = (tags?: string[]) => Boolean(tags?.includes("sponsors_only"));
+
+const maskRequired = (tags?: string[]) => Boolean(tags?.includes("mask_required"));
 
 export const enrichEventRecord = (record: EventRecord): EnrichedEventRecord => ({
     ...record,
@@ -72,8 +82,10 @@ export const enrichEventRecord = (record: EventRecord): EnrichedEventRecord => (
     BannerImageUrl: internalCreateImageUrl(record.BannerImageId),
     PosterImageUrl: internalCreateImageUrl(record.PosterImageId),
     Glyph: tagsToIcon(record.Tags),
+    Badges: tagsToBadges(record.Tags),
     SuperSponsorOnly: superSponsorOnly(record.Tags),
     SponsorOnly: sponsorOnly(record.Tags),
+    MaskRequired: maskRequired(record.Tags)
 });
 
 export const enrichAnnouncementRecord = (record: AnnouncementRecord): EnrichedAnnouncementRecord => ({

--- a/src/store/eurofurence.types.ts
+++ b/src/store/eurofurence.types.ts
@@ -75,9 +75,11 @@ export type EnrichedEventRecord = EventRecord & {
     PartOfDay: PartOfDay;
     PosterImageUrl?: ImageUrl;
     BannerImageUrl?: ImageUrl;
+    Badges?: IconNames[];
     Glyph?: IconNames;
     SuperSponsorOnly: boolean;
     SponsorOnly: boolean;
+    MaskRequired: boolean;
 };
 
 export type DealerRecord = RecordMetadata & {


### PR DESCRIPTION
Should address #45 

1. Added `badges` to EventCardContent  (array of IconNames that show up on top right of card)
2. Added `icon` to Label
3. Update Event Enricher to calculate Badges & MaskRequired