### PR TITLE
fix: use new image URL model

### DIFF
--- a/src/components/announce/AnnouncementCard.tsx
+++ b/src/components/announce/AnnouncementCard.tsx
@@ -19,7 +19,7 @@ export const AnnouncementCard: FC<{ announcement: AnnouncementDetails }> = ({ an
 
             <MarkdownContent>{announcement.Content}</MarkdownContent>
 
-            {announcement.Image && <Image source={announcement.Image.FullUrl} style={styles.image} priority="high" />}
+            {announcement.Image && <Image source={announcement.Image.Url} style={styles.image} priority="high" />}
         </Card>
     );
 };

--- a/src/components/dealers/DealerCard.tsx
+++ b/src/components/dealers/DealerCard.tsx
@@ -48,7 +48,7 @@ export const DealerCard: FC<DealerCardProps> = ({ containerStyle, style, dealer,
     const present = dealer.present;
     const description = dealer.details.Categories?.join(", ");
     const offDays = dealer.offDays;
-    const avatar = dealer.details.ArtistThumbnail ? dealer.details.ArtistThumbnail.FullUrl : dealer.details.Artist ? dealer.details.Artist.FullUrl : assetSource("ych");
+    const avatar = dealer.details.ArtistThumbnail ? dealer.details.ArtistThumbnail.Url : dealer.details.Artist ? dealer.details.Artist.Url : assetSource("ych");
 
     // Translation object.
     const { t } = useTranslation("Dealers");

--- a/src/components/dealers/DealerContent.tsx
+++ b/src/components/dealers/DealerContent.tsx
@@ -89,7 +89,7 @@ export const DealerContent: FC<DealerContentProps> = ({ dealer, parentPad = 0, u
 
             {!dealer.Artist ? null : (
                 <View style={[appStyles.shadow, styles.avatarCircle]}>
-                    <Image contentFit="cover" style={styles.avatarImage} source={dealer.Artist.FullUrl} />
+                    <Image contentFit="cover" style={styles.avatarImage} source={dealer.Artist.Url} />
                 </View>
             )}
 

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -102,7 +102,7 @@ export const EventCard: FC<EventCardProps> = ({ containerStyle, style, type = "d
 
             {event.details.Banner ? (
                 <View style={styles.mainPoster}>
-                    <ImageBackground source={event.details.Banner.FullUrl} contentFit="cover" style={StyleSheet.absoluteFill}>
+                    <ImageBackground source={event.details.Banner.Url} contentFit="cover" style={StyleSheet.absoluteFill}>
                         <View style={styles.tagArea2}>
                             <View style={styles.tagAreaInner}>
                                 <Label style={styles.tag} type="regular" color="white" ellipsizeMode="head" numberOfLines={1}>

--- a/src/components/generic/atoms/Banner.tsx
+++ b/src/components/generic/atoms/Banner.tsx
@@ -46,7 +46,7 @@ export const Banner: FC<BannerProps> = ({ style, image, placeholder, viewable })
                 if (viewable && image) navigation.navigate("Viewer", { id: image.Id });
             }}
         >
-            <Image style={[styles.image, aspect, style]} contentFit={undefined} source={image.FullUrl} placeholder={placeholder} />
+            <Image style={[styles.image, aspect, style]} contentFit={undefined} source={image.Url} placeholder={placeholder} />
         </TouchableOpacity>
     );
 };

--- a/src/components/generic/atoms/ImageFill.tsx
+++ b/src/components/generic/atoms/ImageFill.tsx
@@ -64,9 +64,9 @@ export const ImageFill: FC<ImageFillProps> = ({ style, image, target }) => {
 
     return (
         <View style={[StyleSheet.absoluteFill, style]} onLayout={(e) => setSize(e.nativeEvent.layout)}>
-            <Image style={StyleSheet.absoluteFill} contentFit="cover" blurRadius={20} source={image?.FullUrl} priority="normal" />
+            <Image style={StyleSheet.absoluteFill} contentFit="cover" blurRadius={20} source={image?.Url} priority="normal" />
             <View style={arrangerStyle}>
-                <Image style={imageStyle} contentFit="fill" contentPosition="top left" source={image?.FullUrl} priority="normal" />
+                <Image style={imageStyle} contentFit="fill" contentPosition="top left" source={image?.Url} priority="normal" />
             </View>
         </View>
     );

--- a/src/components/maps/MapContent.tsx
+++ b/src/components/maps/MapContent.tsx
@@ -156,7 +156,7 @@ export const MapContent: FC<MapContentProps> = ({ map, entry, link }) => {
                     onTransform={onTransform}
                 >
                     <View style={styleContainer}>
-                        <Image style={styles.image} allowDownscaling={false} contentFit={undefined} source={map.Image.FullUrl} priority="high" />
+                        <Image style={styles.image} allowDownscaling={false} contentFit={undefined} source={map.Image.Url} priority="high" />
                         {!entry ? null : <Marker style={styleMarker} markerSize={75} />}
                     </View>
                 </ZoomableView>

--- a/src/components/viewer/ViewerImageRecord.tsx
+++ b/src/components/viewer/ViewerImageRecord.tsx
@@ -32,7 +32,7 @@ export const ViewerImageRecord: FC<ViewerImageRecordProps> = ({ id }) => {
 
     return (
         <View style={StyleSheet.absoluteFill}>
-            <Header secondaryIcon="share" secondaryPress={() => image && title && shareImage(image.FullUrl, title)}>
+            <Header secondaryIcon="share" secondaryPress={() => image && title && shareImage(image.Url, title)}>
                 {title}
             </Header>
             {!image ? null : (
@@ -46,7 +46,7 @@ export const ViewerImageRecord: FC<ViewerImageRecordProps> = ({ id }) => {
                     bindToBorders={true}
                 >
                     <View style={styleContainer}>
-                        <Image style={styles.image} allowDownscaling={false} contentFit={undefined} source={image.FullUrl} priority="high" />
+                        <Image style={styles.image} allowDownscaling={false} contentFit={undefined} source={image.Url} priority="high" />
                     </View>
                 </ZoomableView>
             )}

--- a/src/hooks/sync/useImagePrefetch.ts
+++ b/src/hooks/sync/useImagePrefetch.ts
@@ -37,7 +37,7 @@ export const useImagePrefetch = () => {
 
             // Start the prefetch.
             Image.prefetch(
-                images.map((it) => it.FullUrl),
+                images.map((it) => it.Url),
                 "memory-disk",
             )
                 .catch(captureException)

--- a/src/routes/AnnouncementItem.tsx
+++ b/src/routes/AnnouncementItem.tsx
@@ -35,7 +35,7 @@ export const AnnouncementItem = () => {
 
                         <MarkdownContent>{announcement.Content}</MarkdownContent>
 
-                        {announcement.Image && <Image source={announcement.Image.FullUrl} style={styles.image} priority="high" />}
+                        {announcement.Image && <Image source={announcement.Image.Url} style={styles.image} priority="high" />}
                     </>
                 )}
             </Floater>

--- a/src/routes/kb/KbItem.tsx
+++ b/src/routes/kb/KbItem.tsx
@@ -21,7 +21,7 @@ export const KbItem = () => {
             <Header>{entry?.Title}</Header>
             <Floater contentStyle={appStyles.trailer}>
                 {images.map((it) => (
-                    <Image style={styles.image} source={it.FullUrl} key={it.Id} contentFit="contain" />
+                    <Image style={styles.image} source={it.Url} key={it.Id} contentFit="contain" />
                 ))}
                 <MarkdownContent>{entry?.Text ?? ""}</MarkdownContent>
                 {entry?.Links.map((link) => (

--- a/src/store/eurofurence/details.spec.ts
+++ b/src/store/eurofurence/details.spec.ts
@@ -117,15 +117,6 @@ describe("Eurofurence details", () => {
         });
     });
 
-    describe("maps selectors", () => {
-        it("has image with hashes", () => {
-            const results = mapsSelectors.selectAll(state);
-            const withoutHash = results.filter((result) => !result.Image?.FullUrl.includes("with-hash:"));
-
-            expect(withoutHash).toHaveLength(0);
-        });
-    });
-
     describe("special selectors", () => {
         it("finds favorites", () => {
             const id = state.background.notifications.find((n) => n.type === "EventReminder")?.recordId ?? "";

--- a/src/store/eurofurence/details.ts
+++ b/src/store/eurofurence/details.ts
@@ -194,11 +194,6 @@ export const applyMapDetails = (source: MapRecord, images: Dictionary<ImageDetai
     Entries: source.Entries as MapEntryDetails[],
 });
 
-export const applyImageDetails = (source: ImageRecord): ImageDetails => ({
-    ...source,
-    FullUrl: internalCreateImageUrl(source),
-});
-
 const faGlyphToName = Object.fromEntries(Object.entries(FontAwesomeIcon.getRawGlyphMap()).map(([key, value]) => [value, key]));
 
 export const applyKnowledgeGroupDetails = (source: KnowledgeGroupRecord): KnowledgeGroupDetails => ({

--- a/src/store/eurofurence/selectors/records.ts
+++ b/src/store/eurofurence/selectors/records.ts
@@ -4,7 +4,7 @@ import { groupBy, keyBy, map, mapValues, uniq, Dictionary as LodashDictionary } 
 
 import { selectFavoriteDealerIds, selectHiddenEventIds } from "../../auxiliary/selectors";
 import { RootState } from "../../index";
-import { applyAnnouncementDetails, applyDealerDetails, applyEventDayDetails, applyEventDetails, applyImageDetails, applyKnowledgeGroupDetails, applyMapDetails } from "../details";
+import { applyAnnouncementDetails, applyDealerDetails, applyEventDayDetails, applyEventDetails, applyKnowledgeGroupDetails, applyMapDetails } from "../details";
 import {
     announcementsAdapter,
     dealersAdapter,
@@ -64,14 +64,7 @@ export const knowledgeEntriesSelectors = knowledgeEntriesAdapter.getSelectors<Ro
     (state) => state.eurofurenceCache.knowledgeEntries,
 ) as RecordSelectors<KnowledgeEntryDetails>;
 
-const baseImageSelectors = imagesAdapter.getSelectors<RootState>((state) => state.eurofurenceCache.images);
-export const imagesSelectors: RecordSelectors<ImageDetails> = {
-    selectTotal: baseImageSelectors.selectTotal,
-    selectIds: baseImageSelectors.selectIds as (state: RootState) => RecordId[],
-    selectEntities: createSelector([baseImageSelectors.selectEntities], (entities) => mapValues(entities as LodashDictionary<ImageRecord>, applyImageDetails)),
-    selectAll: createSelector([baseImageSelectors.selectAll], (all) => map(all, applyImageDetails)),
-    selectById: createSelector([baseImageSelectors.selectById], (item) => mapOne(item, applyImageDetails)),
-};
+export const imagesSelectors = imagesAdapter.getSelectors<RootState>((state) => state.eurofurenceCache.images) as RecordSelectors<ImageDetails>;
 
 const baseEventDaysSelectors = eventDaysAdapter.getSelectors<RootState>((state) => state.eurofurenceCache.eventDays);
 export const eventDaysSelectors: RecordSelectors<EventDayDetails> = {

--- a/src/store/eurofurence/types.ts
+++ b/src/store/eurofurence/types.ts
@@ -199,16 +199,16 @@ export type KnowledgeEntryRecord = RecordMetadata & {
 export type KnowledgeEntryDetails = KnowledgeEntryRecord & object;
 
 export type ImageRecord = RecordMetadata & {
-    ContentHashSha1: string;
-
-    // Needed because of downsampling.
+    InternalReference: string;
     Width: number;
     Height: number;
+    SizeInBytes: number;
+    MimeType: string;
+    ContentHashSha1: string;
+    Url: string;
 };
 
-export type ImageDetails = ImageRecord & {
-    FullUrl: string;
-};
+export type ImageDetails = ImageRecord & object;
 
 export type CommunicationRecord = RecordMetadata & {
     RecipientUid: string;


### PR DESCRIPTION
* Image URLs are returned in full already and do not need to be fetched at the server.
* Details and Record model adjusted, enrichment removed, applied at all usage sites.