### PR TITLE
chore(config): move convention config out of package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 android
 ios
 
+# Actual settings
+convention.config.json
+
 web-build
 
 .vscode/

--- a/convention.config.dist.json
+++ b/convention.config.dist.json
@@ -1,0 +1,27 @@
+{
+  "convention": {
+    "name": "Eurofurence",
+    "abbreviation": "EF",
+    "identifier": "EF28",
+    "timeZone": "Europe/Berlin",
+    "appBase": "https://app.eurofurence.org/EF28",
+    "apiBase": "https://app.eurofurence.org/EF28/Api",
+    "menuColumns": 3,
+    "showLogin": true,
+    "showServices": true,
+    "showCatchEm": true,
+    "dealerShowAttendee": false
+  },
+  "auth": {
+    "issuer": "https://identity.eurofurence.org",
+    "redirect": "eurofurence://auth/login",
+    "clientId": "<insert-client-id>",
+    "scopes": [
+      "openid",
+      "profile",
+      "offline",
+      "offline_access"
+    ],
+    "settingsUrl": "https://identity.eurofurence.org/settings/profile"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,31 +14,6 @@
       "name": "Luchs (pinselohrkater)"
     }
   ],
-  "convention": {
-    "name": "Eurofurence",
-    "abbreviation": "EF",
-    "identifier": "EF28",
-    "timeZone": "Europe/London",
-    "appBase": "https://app.eurofurence.org/EF28",
-    "apiBase": "https://app.eurofurence.org/EF28/Api",
-    "menuColumns": 3,
-    "showLogin": true,
-    "showServices": true,
-    "showCatchEm": true,
-    "dealerShowAttendee": false
-  },
-  "auth": {
-    "issuer": "https://identity.eurofurence.org",
-    "redirect": "eurofurence://auth/login",
-    "clientId": "a46cc012-dbc8-4992-ab10-581a40c9833e",
-    "scopes": [
-      "openid",
-      "profile",
-      "offline",
-      "offline_access"
-    ],
-    "settingsUrl": "https://identity.eurofurence.org/settings/profile"
-  },
   "license": "MIT",
   "scripts": {
     "start": "expo start",

--- a/src/configuration.tsx
+++ b/src/configuration.tsx
@@ -1,62 +1,62 @@
-import packageData from "../package.json";
+import conventionConfig from "../convention.config.json";
 
 /**
  * The name of the convention.
  */
-export const conName = packageData.convention.name;
+export const conName = conventionConfig.convention.name;
 
 /**
  * The abbreviation for the convention name.
  */
-export const conAbbr = packageData.convention.abbreviation;
+export const conAbbr = conventionConfig.convention.abbreviation;
 
 /**
  * Convention identifier.
  */
-export const conId = packageData.convention.identifier;
+export const conId = conventionConfig.convention.identifier;
 
 /**
  * Convention time zone.
  */
-export const conTimeZone = packageData.convention.timeZone;
+export const conTimeZone = conventionConfig.convention.timeZone;
 
 /**
  * App base, non-API URLs are relative to this.
  */
-export const appBase = packageData.convention.appBase;
+export const appBase = conventionConfig.convention.appBase;
 
 /**
  * API base, API methods are under this URL.
  */
-export const apiBase = packageData.convention.apiBase;
+export const apiBase = conventionConfig.convention.apiBase;
 
 /**
  * Number of columns to use in main menu pager.
  */
-export const menuColumns = packageData.convention.menuColumns;
+export const menuColumns = conventionConfig.convention.menuColumns;
 
 /**
  * True if login is available for this convention.
  */
-export const showLogin = packageData.convention.showLogin;
+export const showLogin = conventionConfig.convention.showLogin;
 
 /**
  * True if services are available for this convention.
  */
-export const showServices = packageData.convention.showServices;
+export const showServices = conventionConfig.convention.showServices;
 
 /**
  * True if catch-em-all game is available for this convention.
  */
-export const showCatchEm = packageData.convention.showCatchEm;
+export const showCatchEm = conventionConfig.convention.showCatchEm;
 
 /**
  * True if dealer view shows attendee.
  */
-export const dealerShowAttendee = packageData.convention.dealerShowAttendee;
+export const dealerShowAttendee = conventionConfig.convention.dealerShowAttendee;
 
-export const authIssuer = packageData.auth.issuer;
-export const authRedirect = packageData.auth.redirect;
-export const authClientId = packageData.auth.clientId;
-export const authScopes = packageData.auth.scopes;
-export const authSettingsUrl = packageData.auth.settingsUrl;
+export const authIssuer = conventionConfig.auth.issuer;
+export const authRedirect = conventionConfig.auth.redirect;
+export const authClientId = conventionConfig.auth.clientId;
+export const authScopes = conventionConfig.auth.scopes;
+export const authSettingsUrl = conventionConfig.auth.settingsUrl;


### PR DESCRIPTION
Convention-specific configuration has been moved to `convention.config.dist.json` which locally needs to be copied (and potentially updated) to `convention.config.json` when building/running the app, to avoid accidental data disclosure.