### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,6 @@
 name: Lint and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eurofurence/ef-app_react-native/security/code-scanning/1](https://github.com/eurofurence/ef-app_react-native/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since this workflow only performs linting and testing, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents without granting unnecessary write access.

The `permissions` block will be added immediately after the `name` field at the top of the file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
