### PR TITLE
Fix/event reminder immediate scheduling

### DIFF
--- a/src/__tests__/AnnounceItem.test.tsx
+++ b/src/__tests__/AnnounceItem.test.tsx
@@ -33,7 +33,11 @@ jest.mock('react-i18next', () => ({
 // Mock date-fns
 jest.mock('date-fns', () => ({
   format: jest.fn(() => 'Jan 1, 2022, 12:00 AM'),
-  parseISO: jest.fn(() => new Date('2022-01-01T00:00:00Z')),
+}))
+
+// Mock date-fns
+jest.mock('@/util/parseDefaultISO', () => ({
+  parseDefaultISO: jest.fn(() => new Date('2022-01-01T00:00:00Z')),
 }))
 
 // Mock ToastContext

--- a/src/__tests__/parseDefaultISO.test.ts
+++ b/src/__tests__/parseDefaultISO.test.ts
@@ -1,0 +1,31 @@
+import { parseDefaultISO } from '@/util/parseDefaultISO'
+
+describe('parseDefaultISO', () => {
+  it('should assume Zulu default', () => {
+    const actual = parseDefaultISO('2025-09-03T20:00:00.000')
+    const reference = new Date('2025-09-03T20:00:00.000Z')
+    expect(actual).toEqual(reference)
+  })
+
+  it('should understand Zulu as specified', () => {
+    const actual = parseDefaultISO('2025-09-03T20:00:00.000Z')
+    const reference = new Date('2025-09-03T20:00:00.000Z')
+    expect(actual).toEqual(reference)
+  })
+
+  it('should not assume zulu when positive timezone specified', () => {
+    const actual = parseDefaultISO('2025-09-03T20:00:00.000+02:00')
+    const reference1 = new Date('2025-09-03T20:00:00.000Z')
+    const reference2 = new Date('2025-09-03T20:00:00.0000+02:00')
+    expect(actual).not.toEqual(reference1)
+    expect(actual).toEqual(reference2)
+  })
+
+  it('should not assume zulu when negative timezone specified', () => {
+    const actual = parseDefaultISO('2025-09-03T20:00:00.000-02:00')
+    const reference1 = new Date('2025-09-03T20:00:00.000Z')
+    const reference2 = new Date('2025-09-03T20:00:00.0000-02:00')
+    expect(actual).not.toEqual(reference1)
+    expect(actual).toEqual(reference2)
+  })
+})

--- a/src/app/announcements/[id].tsx
+++ b/src/app/announcements/[id].tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { StyleSheet, View, ScrollView } from 'react-native'
 import { useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
-import { format, parseISO } from 'date-fns'
+import { format } from 'date-fns'
 
 import { appStyles } from '@/components/AppStyles'
 import { Banner } from '@/components/generic/atoms/Banner'
@@ -13,6 +13,7 @@ import { Header } from '@/components/generic/containers/Header'
 import { Row } from '@/components/generic/containers/Row'
 import { Rule } from '@/components/generic/atoms/Rule'
 import { useCache } from '@/context/data/Cache'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 export default function AnnounceItem() {
   const { t } = useTranslation('Announcement')
@@ -35,7 +36,7 @@ export default function AnnounceItem() {
             </Label>
 
             <Row style={styles.byline} variant="spaced">
-              <Label>{format(parseISO(announcement.ValidFromDateTimeUtc), 'PPpp')}</Label>
+              <Label>{format(parseDefaultISO(announcement.ValidFromDateTimeUtc), 'PPpp')}</Label>
 
               <Label style={styles.tag} ellipsizeMode="head" numberOfLines={1}>
                 {announcement.Area} - {announcement.Author}

--- a/src/app/messages/[id].tsx
+++ b/src/app/messages/[id].tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { StyleSheet, ScrollView } from 'react-native'
 import { useTranslation } from 'react-i18next'
-import { parseISO, format } from 'date-fns'
+import { format } from 'date-fns'
 import { useLocalSearchParams, router, Redirect } from 'expo-router'
 
 import { appStyles } from '@/components/AppStyles'
@@ -15,6 +15,7 @@ import { useThemeBackground } from '@/hooks/themes/useThemeHooks'
 import { useCommunicationsMarkReadMutation } from '@/hooks/api/communications/useCommunicationsMarkReadMutation'
 
 import { useCommunicationsItemQuery } from '@/hooks/api/communications/useCommunicationsQuery'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 const readOpenTimeRequirement = 1500
 
@@ -45,7 +46,7 @@ export default function MessageItem() {
 
   if (!message) return <Redirect href="/messages" />
 
-  const formattedDate = message.ReceivedDateTimeUtc ? format(parseISO(message.ReceivedDateTimeUtc), 'PPpp') : ''
+  const formattedDate = message.ReceivedDateTimeUtc ? format(parseDefaultISO(message.ReceivedDateTimeUtc), 'PPpp') : ''
 
   return (
     <ScrollView style={[StyleSheet.absoluteFill, backgroundStyle]} stickyHeaderIndices={[0]} stickyHeaderHiddenOnScroll>

--- a/src/components/events/UpcomingEventsList.tsx
+++ b/src/components/events/UpcomingEventsList.tsx
@@ -2,17 +2,17 @@ import React, { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, View } from 'react-native'
 
-import { isWithinInterval, parseISO, subMinutes } from 'date-fns'
+import { isWithinInterval, subMinutes } from 'date-fns'
 import { Section } from '../generic/atoms/Section'
 import { EventCard, eventInstanceForAny } from './EventCard'
 import { useCache } from '@/context/data/Cache'
 import { EventDetails } from '@/context/data/types.details'
 import { useEventCardInteractions } from '@/components/events/Events.common'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 const filterUpcomingEvents = (events: readonly EventDetails[], now: Date) =>
   events.filter((it) => {
-    // TODO: Properly fix this.
-    const startDate = parseISO(it.StartDateTimeUtc + 'Z')
+    const startDate = parseDefaultISO(it.StartDateTimeUtc)
     const startMinus30 = subMinutes(startDate, 30)
     return isWithinInterval(now, { start: startMinus30, end: startDate })
   })

--- a/src/components/home/CountdownHeader.tsx
+++ b/src/components/home/CountdownHeader.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleProp, StyleSheet, useWindowDimensions, View, ViewStyle } from 'react-native'
 
 import { fromZonedTime } from 'date-fns-tz' // Import from date-fns-tz package
-import { formatDistance, isSameDay, parseISO } from 'date-fns' // Import date-fns utilities
+import { formatDistance, isSameDay } from 'date-fns' // Import date-fns utilities
 import { Image } from '../generic/atoms/Image'
 import { ImageBackground } from '../generic/atoms/ImageBackground'
 import { Label, labelTypeStyles } from '../generic/atoms/Label'
@@ -14,6 +14,7 @@ import { useNow } from '@/hooks/time/useNow'
 import { conId, conName, conTimeZone } from '@/configuration'
 import { EventDayRecord } from '@/context/data/types.api'
 import { useCache } from '@/context/data/Cache'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 export type CountdownHeaderProps = {
   style?: StyleProp<ViewStyle>
@@ -26,7 +27,7 @@ const bannerBreakpoint = 600
  */
 const isSameDayInTimezone = (date1: Date, date2: string, timezone: string) => {
   const localDate1 = fromZonedTime(date1, timezone) // Convert date1 to UTC based on the timezone
-  const localDate2 = fromZonedTime(parseISO(date2), timezone) // Convert date2 (event date) to UTC based on the timezone
+  const localDate2 = fromZonedTime(parseDefaultISO(date2), timezone) // Convert date2 (event date) to UTC based on the timezone
 
   return isSameDay(localDate1, localDate2) // Compare the two dates
 }

--- a/src/context/data/useCacheExtensions.derived.ts
+++ b/src/context/data/useCacheExtensions.derived.ts
@@ -1,10 +1,11 @@
-import { getHours, parseISO } from 'date-fns'
+import { getHours } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 import { flatMap, maxBy, uniq } from 'lodash'
 import { DealerRecord } from './types.api'
 import { IconNames } from '@/components/generic/atoms/Icon'
 import { conTimeZone } from '@/configuration'
 import { AttendanceDay, EventDayDetails } from '@/context/data/types.details'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 export function deriveHosts(panelHosts: string | undefined) {
   return (
@@ -16,7 +17,7 @@ export function deriveHosts(panelHosts: string | undefined) {
 }
 
 export function deriveCategorizedTime(dateStr: string) {
-  const date = toZonedTime(parseISO(dateStr), conTimeZone)
+  const date = toZonedTime(parseDefaultISO(dateStr), conTimeZone)
   const hours = getHours(date)
   if (6 <= hours && hours < 13) return 'morning'
   if (13 <= hours && hours < 17) return 'afternoon'

--- a/src/context/data/useCacheExtensions.ts
+++ b/src/context/data/useCacheExtensions.ts
@@ -15,7 +15,6 @@ import {
   deriveIsSuperSponsorsOnly,
   deriveProfileUrlFromMastodonHandle,
 } from '@/context/data/useCacheExtensions.derived'
-import { parseISO } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 import Fuse from 'fuse.js'
 import { chain } from 'lodash'
@@ -49,6 +48,7 @@ import {
   useFuseMemo,
   useFuseRecordMemo,
 } from '@/context/data/useCacheExtensions.searching'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 /**
  * Resolved detailed entity data.
@@ -214,10 +214,10 @@ export const useCacheExtensions = (data: StoreData): CacheExtensions => {
       ...item,
       NormalizedTitle: deriveAnnouncementTitle(item.Title, item.Content),
       Image: item.ImageId ? images?.dict?.[item.ImageId] : undefined,
-      ValidFrom: toZonedTime(parseISO(item.ValidFromDateTimeUtc + 'Z'), conTimeZone),
-      ValidFromLocal: parseISO(item.ValidFromDateTimeUtc + 'Z'),
-      ValidUntil: toZonedTime(parseISO(item.ValidUntilDateTimeUtc + 'Z'), conTimeZone),
-      ValidUntilLocal: parseISO(item.ValidUntilDateTimeUtc + 'Z'),
+      ValidFrom: toZonedTime(parseDefaultISO(item.ValidFromDateTimeUtc), conTimeZone),
+      ValidFromLocal: parseDefaultISO(item.ValidFromDateTimeUtc),
+      ValidUntil: toZonedTime(parseDefaultISO(item.ValidUntilDateTimeUtc), conTimeZone),
+      ValidUntilLocal: parseDefaultISO(item.ValidUntilDateTimeUtc),
     }))
   }, [images, data.announcements])
 
@@ -234,7 +234,7 @@ export const useCacheExtensions = (data: StoreData): CacheExtensions => {
   const eventDays = useMemo((): EntityStore<EventDayDetails> => {
     return mapEntityStore(data.eventDays, (item) => ({
       ...item,
-      DayOfWeek: toZonedTime(parseISO(item.Date + 'Z'), conTimeZone).getDay(),
+      DayOfWeek: toZonedTime(parseDefaultISO(item.Date), conTimeZone).getDay(),
     }))
   }, [data.eventDays])
 
@@ -274,10 +274,10 @@ export const useCacheExtensions = (data: StoreData): CacheExtensions => {
         ConferenceRoom: item.ConferenceRoomId ? eventRooms?.dict?.[item.ConferenceRoomId] : undefined,
         ConferenceDay: item.ConferenceDayId ? eventDays?.dict?.[item.ConferenceDayId] : undefined,
         ConferenceTrack: item.ConferenceTrackId ? eventTracks?.dict?.[item.ConferenceTrackId] : undefined,
-        Start: toZonedTime(parseISO(item.StartDateTimeUtc + 'Z'), conTimeZone),
-        StartLocal: parseISO(item.StartDateTimeUtc + 'Z'),
-        End: toZonedTime(parseISO(item.EndDateTimeUtc + 'Z'), conTimeZone),
-        EndLocal: parseISO(item.EndDateTimeUtc + 'Z'),
+        Start: toZonedTime(parseDefaultISO(item.StartDateTimeUtc), conTimeZone),
+        StartLocal: parseDefaultISO(item.StartDateTimeUtc),
+        End: toZonedTime(parseDefaultISO(item.EndDateTimeUtc), conTimeZone),
+        EndLocal: parseDefaultISO(item.EndDateTimeUtc),
         Favorite: Boolean(favoriteIds?.includes(item.Id)),
         Hidden: Boolean(data.settings.hiddenEvents?.includes(item.Id)),
       })

--- a/src/hooks/api/communications/useCommunicationsMarkReadMutation.ts
+++ b/src/hooks/api/communications/useCommunicationsMarkReadMutation.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import axios, { GenericAbortSignal } from 'axios'
 import { apiBase } from '@/configuration'
 import { queryClient } from '@/context/query/Query'
-import { parseISO } from 'date-fns'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 /**
  * Posts communication read to the API with the given access token, message ID, and optionally an abort signal.
@@ -21,7 +21,7 @@ export async function postCommunicationsMarkRead(accessToken: string | null, id:
         'Content-Type': 'application/json',
       },
     })
-    .then((res) => parseISO(res.data))
+    .then((res) => parseDefaultISO(res.data))
 }
 
 /**

--- a/src/hooks/api/registration/useRegistrationDatesQuery.ts
+++ b/src/hooks/api/registration/useRegistrationDatesQuery.ts
@@ -1,7 +1,7 @@
 import { keepPreviousData, useQuery, UseQueryResult } from '@tanstack/react-query'
 import axios, { GenericAbortSignal } from 'axios'
-import { parseISO } from 'date-fns'
 import { registrationDatesUrl } from '@/configuration'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 interface RegistrationDates {
   'reg-start': string
@@ -26,8 +26,8 @@ export async function getRegistrationDates(signal?: GenericAbortSignal): Promise
 
   const data: RegistrationDates = response.data
 
-  const parsedStartDate = parseISO(data['reg-start'])
-  const parsedEndDate = parseISO(data['reg-end'])
+  const parsedStartDate = parseDefaultISO(data['reg-start'])
+  const parsedEndDate = parseDefaultISO(data['reg-end'])
 
   if (isNaN(parsedStartDate.getTime())) {
     throw new Error('Invalid start date format received from server')

--- a/src/hooks/data/useEventReminderRescheduling.ts
+++ b/src/hooks/data/useEventReminderRescheduling.ts
@@ -1,8 +1,9 @@
-import { isAfter, parseISO } from 'date-fns'
+import { isAfter } from 'date-fns'
 import { useEffect, useRef } from 'react'
 import { useCache } from '@/context/data/Cache'
 import { Notification } from '@/store/background/slice'
 import { cancelEventReminder, rescheduleEventReminder } from '@/util/eventReminders'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 /**
  * Synchronizes currently scheduled device notifications with incoming event
@@ -50,7 +51,7 @@ export function useEventReminderRescheduling() {
         // Event is still present. But it might have changed.
         if (event) {
           // Check if changed. If so, reschedule it,
-          if (isAfter(parseISO(event.LastChangeDateTimeUtc), parseISO(notification.dateCreatedUtc))) {
+          if (isAfter(parseDefaultISO(event.LastChangeDateTimeUtc), parseDefaultISO(notification.dateCreatedUtc))) {
             await rescheduleEventReminder(event, 0, add, remove).catch((error) => console.warn('Reschedule error:', error))
           }
         } else {

--- a/src/hooks/data/useUpdateSinceNote.ts
+++ b/src/hooks/data/useUpdateSinceNote.ts
@@ -1,8 +1,9 @@
 import { useEffect, useMemo } from 'react'
-import { isAfter, parseISO } from 'date-fns'
+import { isAfter } from 'date-fns'
 import { useNow } from '@/hooks/time/useNow'
 import { RecordMetadata } from '@/context/data/types.api'
 import { useCache } from '@/context/data/Cache'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 /**
  * Gets the last viewed time of this record and if the record has changed
@@ -17,7 +18,7 @@ export const useUpdateSinceNote = (item: RecordMetadata | null | undefined, dela
   const settings = getValue('settings')
   const lastViewed = item ? (settings.lastViewTimes?.[item.Id] ?? null) : null
 
-  const updated = useMemo(() => Boolean(item && lastViewed && isAfter(parseISO(item.LastChangeDateTimeUtc), parseISO(lastViewed))), [item, lastViewed])
+  const updated = useMemo(() => Boolean(item && lastViewed && isAfter(parseDefaultISO(item.LastChangeDateTimeUtc), parseDefaultISO(lastViewed))), [item, lastViewed])
 
   useEffect(() => {
     if (!item) return

--- a/src/store/background/slice.tsx
+++ b/src/store/background/slice.tsx
@@ -2,6 +2,7 @@ import { RecordId } from '@/context/data/types.api'
 
 export type Notification = {
   recordId: RecordId
+  identifier?: string
   type: 'EventReminder'
   dateScheduledUtc: string
   dateCreatedUtc: string

--- a/src/util/eventReminders.ts
+++ b/src/util/eventReminders.ts
@@ -1,20 +1,21 @@
 import * as Notifications from 'expo-notifications'
 import { Platform } from 'react-native'
 import { captureException } from '@sentry/react-native'
-import { format, isBefore, subMilliseconds, subMinutes } from 'date-fns'
+import { isBefore, subMilliseconds, subMinutes } from 'date-fns'
 import { conId } from '@/configuration'
 import { Notification } from '@/store/background/slice'
-import { EventRecord, RecordId } from '@/context/data/types.api'
+import { EventRecord } from '@/context/data/types.api'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
+import { SchedulableTriggerInputTypes } from 'expo-notifications'
 
-export async function scheduleEventReminder(event: EventRecord, timeTravel: number, save: (notification: Notification) => void) {
+export async function scheduleEventReminder(event: EventRecord, timeTravel: number): Promise<Notification> {
   // Get relevant UTC times.
   const dateCreatedUtc = new Date()
-  const dateScheduleUtc = subMinutes(subMilliseconds(new Date(event.StartDateTimeUtc), timeTravel), 30)
+  const dateScheduleUtc = subMinutes(subMilliseconds(parseDefaultISO(event.StartDateTimeUtc), timeTravel), 30)
 
   // If platform is on device, schedule actual notification.
   if ((Platform.OS === 'android' || Platform.OS === 'ios') && isBefore(dateCreatedUtc, dateScheduleUtc)) {
-    await Notifications.scheduleNotificationAsync({
-      identifier: event.Id,
+    const identifier = await Notifications.scheduleNotificationAsync({
       content: {
         title: event.Title,
         subtitle: 'This event is starting soon!',
@@ -26,34 +27,33 @@ export async function scheduleEventReminder(event: EventRecord, timeTravel: numb
       },
       trigger: {
         date: dateScheduleUtc,
+        type: SchedulableTriggerInputTypes.DATE,
         channelId: 'event_reminders',
       },
     })
-  }
 
-  // Save notification to cache.
-  save({
-    recordId: event.Id,
-    type: 'EventReminder',
-    dateCreatedUtc: format(dateCreatedUtc, "yyyy-MM-dd'T'HH:mm:ssXXX"),
-    dateScheduledUtc: format(dateScheduleUtc, "yyyy-MM-dd'T'HH:mm:ssXXX"),
-  })
+    // Save notification to cache.
+    return {
+      recordId: event.Id,
+      identifier: identifier,
+      type: 'EventReminder',
+      dateCreatedUtc: dateCreatedUtc.toISOString(),
+      dateScheduledUtc: dateScheduleUtc.toISOString(),
+    }
+  } else {
+    // Save notification to cache.
+    return {
+      recordId: event.Id,
+      type: 'EventReminder',
+      dateCreatedUtc: dateCreatedUtc.toISOString(),
+      dateScheduledUtc: dateScheduleUtc.toISOString(),
+    }
+  }
 }
 
-export async function cancelEventReminder(event: EventRecord | RecordId, remove: (id: string) => void) {
-  // Get actual identifier, might be called without an instance.
-  const identifier = typeof event === 'string' ? event : event.Id
-
+export async function cancelEventReminder(notification: Notification) {
   // If platform is on device, cancel actual notification.
-  if (Platform.OS === 'android' || Platform.OS === 'ios') {
-    await Notifications.cancelScheduledNotificationAsync(identifier).catch((error) => captureException(error, { level: 'warning' }))
+  if ((Platform.OS === 'android' || Platform.OS === 'ios') && typeof notification.identifier === 'string') {
+    await Notifications.cancelScheduledNotificationAsync(notification.identifier).catch((error) => captureException(error, { level: 'warning' }))
   }
-
-  // Remove notification from cache.
-  remove(identifier)
-}
-
-export async function rescheduleEventReminder(event: EventRecord, timeTravel: number, save: (notification: Notification) => void, remove: (id: string) => void) {
-  await cancelEventReminder(event, remove)
-  await scheduleEventReminder(event, timeTravel, save)
 }

--- a/src/util/eventTiming.ts
+++ b/src/util/eventTiming.ts
@@ -1,9 +1,10 @@
-import { differenceInMilliseconds, parseISO } from 'date-fns'
+import { differenceInMilliseconds } from 'date-fns'
 import { format, toZonedTime } from 'date-fns-tz'
 import { de } from 'date-fns/locale/de'
 import { conTimeZone } from '@/configuration'
 
 import { EventDetails } from '@/context/data/types.details'
+import { parseDefaultISO } from '@/util/parseDefaultISO'
 
 export function calculateEventTiming(details: EventDetails, now: Date | 'done') {
   // Calculate progress
@@ -41,7 +42,7 @@ export function calculateEventTiming(details: EventDetails, now: Date | 'done') 
  * @returns The formatted weekday name
  */
 export function formatWeekdayInConventionTimezone(dateStr: string): string {
-  const date = parseISO(dateStr)
+  const date = parseDefaultISO(dateStr)
   const zonedDate = toZonedTime(date, conTimeZone)
   return format(zonedDate, 'EEEE', { timeZone: conTimeZone })
 }

--- a/src/util/parseDefaultISO.ts
+++ b/src/util/parseDefaultISO.ts
@@ -1,0 +1,34 @@
+import { parseISO, ParseISOOptions } from 'date-fns/parseISO'
+
+/**
+ * Checks if the argument specifies a timezone.
+ * @param argument The argument to check.
+ */
+function hasTimeZoneSpecifier(argument: unknown) {
+  // Guard type.
+  if (typeof argument !== 'string') return false
+
+  // Find ISO time separator, we later check for timezone offsets and this lets
+  // us skip 'minus' symbols in the date part. If no time separator is
+  // found, cannot have time zone specifier.
+  const timeSeparator = argument.indexOf('T')
+  if (timeSeparator < 0) return false
+
+  return (
+    // Positive time zone adjustment.
+    argument.indexOf('+', timeSeparator) > 0 ||
+    // Negative time zone adjustment.
+    argument.indexOf('-', timeSeparator) > 0 ||
+    // Zulu time.
+    argument.indexOf('Z', timeSeparator) > 0
+  )
+}
+
+/**
+ * Parses an ISO date, applies default time zone assumption if no timezone is specified.
+ * @param argument The argument to parse.
+ * @param options Any options.
+ */
+export function parseDefaultISO<DateType extends Date, ResultDate extends Date = DateType>(argument: string, options?: ParseISOOptions<ResultDate>): ResultDate {
+  return hasTimeZoneSpecifier(argument) ? parseISO(argument, options) : parseISO<DateType, ResultDate>(argument + 'Z', options)
+}


### PR DESCRIPTION
fix: Immediate reminder scheduling

Based on #315 

* Event reminder hook code refactored. No-callback variants of notification scheduling and removal.
* Changed implementation of rescheduling, no-callback code with inline update of notifications to store.
* Add optional platform identifier to the notification storage type.
* Make scheduling and canceling no-callback. Return notification to be scheduled. Add trigger type. Set identifier from scheduling instead of from input. Remove rescheduling method, no-callback works better on call-site.