### PR TITLE
Fix/dont reset tokens on claims failure

### DIFF
--- a/src/app/artists-alley/index.tsx
+++ b/src/app/artists-alley/index.tsx
@@ -9,7 +9,6 @@ import { useCache } from '@/context/data/Cache'
 import { TableRegistrationRecord } from '@/context/data/types.api'
 import { ArtistAlleyDetails } from '@/context/data/types.details'
 import { Label } from '@/components/generic/atoms/Label'
-import { useIsFocused } from '@react-navigation/core'
 import { useUserContext } from '@/context/auth/User'
 import { useAuthContext } from '@/context/auth/Auth'
 import { captureException } from '@sentry/react-native'
@@ -32,12 +31,6 @@ export default function List() {
   const isCheckedIn = Boolean(user?.RoleMap?.AttendeeCheckedIn)
   const isPrivileged = Boolean(user?.RoleMap?.Admin) || Boolean(user?.RoleMap?.ArtistAlleyAdmin) || Boolean(user?.RoleMap?.ArtistAlleyModerator)
   const isAuthorized = isCheckedIn || isPrivileged
-
-  // Sync on focus, artist alley data might change more frequently than other parts of the app.
-  const isFocused = useIsFocused()
-  useEffect(() => {
-    if (isFocused) synchronize().catch(console.error)
-  }, [isFocused, synchronize])
 
   useEffect(() => {
     if (isAuthorized) {

--- a/src/components/artists-alley/ArtistsAlleyCard.tsx
+++ b/src/components/artists-alley/ArtistsAlleyCard.tsx
@@ -37,44 +37,45 @@ export const ArtistsAlleyCard: FC<ArtistsAlleyCardProps> = ({ containerStyle, st
   })
 
   return (
-    <Pressable
-      containerStyle={containerStyle}
-      style={[styles.container, appStyles.shadow, styleContainer, style]}
-      onPress={() => onPress?.(item)}
-      onLongPress={() => onLongPress?.(item)}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      accessibilityHint={tAccessibility('card_button_hint')}
-      accessibilityState={{
-        selected: false,
-        disabled: false,
-      }}
-    >
-      <ImageBackground style={[styles.pre, stylePre]} source={sourceFromImage(item.Image)}>
-        <View style={[styles.tableContainer, styleDarken]}>
-          <Label type="cap" color={'white'}>
-            Table
+    <View style={containerStyle}>
+      <Pressable
+        style={[styles.container, appStyles.shadow, styleContainer, style]}
+        onPress={() => onPress?.(item)}
+        onLongPress={() => onLongPress?.(item)}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={tAccessibility('card_button_hint')}
+        accessibilityState={{
+          selected: false,
+          disabled: false,
+        }}
+      >
+        <ImageBackground style={[styles.pre, stylePre]} source={sourceFromImage(item.Image)}>
+          <View style={[styles.tableContainer, styleDarken]}>
+            <Label type="cap" color={'white'}>
+              Table
+            </Label>
+            <Label type="h3" color={'white'}>
+              {item.Location}
+            </Label>
+          </View>
+          <View style={[styles.areaIndicator, styleAreaIndicator]} />
+        </ImageBackground>
+
+        <View style={styles.main}>
+          <Label style={styles.title} type="h3">
+            {'OwnerUsername' in item ? item.OwnerUsername + ' (' + item.OwnerRegSysId + ') — ' : ''}
+            {item.DisplayName}
           </Label>
-          <Label type="h3" color={'white'}>
-            {item.Location}
+          <Label type="h4" variant="narrow">
+            {item.ShortDescription}
+          </Label>
+          <Label style={styles.tag} type="regular" ellipsizeMode="head" numberOfLines={1}>
+            {'State' in item ? item.State : ''}
           </Label>
         </View>
-        <View style={[styles.areaIndicator, styleAreaIndicator]} />
-      </ImageBackground>
-
-      <View style={styles.main}>
-        <Label style={styles.title} type="h3">
-          {'OwnerUsername' in item ? item.OwnerUsername + ' (' + item.OwnerRegSysId + ') — ' : ''}
-          {item.DisplayName}
-        </Label>
-        <Label type="h4" variant="narrow">
-          {item.ShortDescription}
-        </Label>
-        <Label style={styles.tag} type="regular" ellipsizeMode="head" numberOfLines={1}>
-          {'State' in item ? item.State : ''}
-        </Label>
-      </View>
-    </Pressable>
+      </Pressable>
+    </View>
   )
 }
 

--- a/src/components/generic/atoms/Search.tsx
+++ b/src/components/generic/atoms/Search.tsx
@@ -53,6 +53,7 @@ export const Search: FC<SearchProps> = ({ style, filter, setFilter, placeholder,
       {filter ? (
         <Pressable
           onPress={() => setFilter('')}
+          style={styles.clearButtonContainer}
           accessibilityRole="button"
           accessibilityLabel={t('clear_search', { defaultValue: 'Clear search' })}
           accessibilityHint={t('clear_search_hint', { defaultValue: 'Clears the current search text' })}
@@ -81,6 +82,10 @@ const styles = StyleSheet.create({
   },
   iconClear: {
     // Icon positioning handled by touch target container
+  },
+  clearButtonContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   clearButton: {
     // Additional styles merged with touch target styles


### PR DESCRIPTION
fix: Don't reset token on claims failure

* Typecheck function added to auth context.
* Don't reset token on claims failure (refresh might cause a token to be invalid and then claims will prevent new token to be comitted).
* Throw properly and handle background failures properly.

fix: Layout issues

* Don't refresh on AA index.
* Artist alley card container pattern fixed.
* Search clear icon alignment fixed.