### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ on:
                 default: true
 jobs:
     build:
+        permissions:
+            contents: write
         runs-on: ${{ github.event.inputs.os }}
         strategy:
             matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/eurofurence/ef-app_react-native/security/code-scanning/6](https://github.com/eurofurence/ef-app_react-native/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block to the workflow. Since only the release step requires `contents: write`, you can set the default permissions at the workflow level to `contents: read` (the minimum), and then override the permissions for the `build` job (or just for the release step's job) to `contents: write`. However, since there is only one job (`build`), and only one step needs `write`, the simplest and most secure approach is to set `permissions: contents: write` at the job level for `build`. Alternatively, you could set `permissions: contents: read` at the workflow level and override it for the job, but since the job needs to create a release, setting it at the job level is sufficient.

**Steps:**
- Add a `permissions` block under the `build` job (line 30), with `contents: write`.
- No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
