### PR TITLE
Bump Android compile/target SDK to 36

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -45,8 +45,6 @@ module.exports = {
       package: 'org.eurofurence.connavigator',
       icon: './assets/platform/appicon-android.png',
       googleServicesFile: './assets/platform/google-services.json',
-      targetSdkVersion: 36,
-      compileSdkVersion: 36,
       newArchEnabled: true,
       splash: {
         resizeMode: 'native',
@@ -144,9 +142,9 @@ module.exports = {
             privacyManifestAggregationEnabled: true,
           },
           android: {
-            compileSdkVersion: 35,
-            targetSdkVersion: 35,
-            buildToolsVersion: '35.0.0',
+            compileSdkVersion: 36,
+            targetSdkVersion: 36,
+            buildToolsVersion: '36.0.0',
           },
         },
       ],


### PR DESCRIPTION
Android builds fail after #372 with an AAR metadata error: dependencies require `compileSdk 36`, but it still pins `expo-build-properties` to 35.

## Changes

- Bump Android SDK target to 36.
- Remove redundant top-level `android` config targets as they were shadowed by the plugin config and have been dead code.  
