### PR TITLE
fix: hide user state when not logged in

### DIFF
--- a/src/context/auth/User.tsx
+++ b/src/context/auth/User.tsx
@@ -73,24 +73,26 @@ export const UserProvider = ({
 }: {
   children?: ReactNode | undefined
 }) => {
-  const { idData, refreshToken } = useAuthContext()
-
+  const { idData, loggedIn, refreshToken } = useAuthContext()
   const { data: claims, refetch: refetchClaims } = useUserInfo()
   const { data: user, refetch: refetchSelf } = useUsersSelf()
 
   // Get value to provide to the children.
-  const value = useMemo<UserContextType>(
-    () => ({
-      claims: claims ?? idToClaims(idData) ?? null,
+  const value = useMemo<UserContextType>(() => {
+    const refresh = async () => {
+      await refreshToken()
+      await refetchClaims()
+      await refetchSelf()
+    }
+
+    if (!loggedIn) return { claims: null, user: null, refresh }
+
+    return {
+      claims: claims ?? idToClaims(idData),
       user: user ?? null,
-      refresh: async () => {
-        await refreshToken()
-        await refetchClaims()
-        await refetchSelf()
-      },
-    }),
-    [idData, claims, user, refreshToken, refetchClaims, refetchSelf]
-  )
+      refresh,
+    }
+  }, [idData, loggedIn, claims, user, refreshToken, refetchClaims, refetchSelf])
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>
 }

--- a/src/hooks/api/idp/useUserInfo.ts
+++ b/src/hooks/api/idp/useUserInfo.ts
@@ -37,10 +37,11 @@ export async function getUserInfo(
  * Uses a query for `getUserInfo` with the app auth state.
  */
 export function useUserInfo(): UseQueryResult<Claims | null> {
-  const { accessToken, idData } = useAuthContext()
+  const { accessToken, idData, loggedIn } = useAuthContext()
   return useQuery({
     queryKey: [idData?.sub, 'user-info'],
     queryFn: (context) => getUserInfo(accessToken, context.signal),
     placeholderData: (data) => keepPreviousData(data),
+    enabled: loggedIn,
   })
 }

--- a/src/hooks/api/users/useUsersSelf.ts
+++ b/src/hooks/api/users/useUsersSelf.ts
@@ -50,7 +50,7 @@ async function getUserSelf(
 }
 
 export function useUsersSelf(): UseQueryResult<UserDetails | null> {
-  const { accessToken, idData } = useAuthContext()
+  const { accessToken, idData, loggedIn } = useAuthContext()
   // Wrap self query. Add some options.
   return useQuery({
     queryKey: [idData?.sub, 'self'],
@@ -59,5 +59,6 @@ export function useUsersSelf(): UseQueryResult<UserDetails | null> {
     placeholderData: (data) => keepPreviousData(data),
     refetchInterval: 60_000,
     retry: false,
+    enabled: loggedIn,
   })
 }


### PR DESCRIPTION
User info is now properly hidden when the user logs out or auth is lost.

Fixes #354