### PR TITLE
Fix/sentry plugin config duplicate issue

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -92,7 +92,6 @@ module.exports = {
     plugins: [
       // Run sentry plugin only if auth token is given, otherwise the build crashes.
       Boolean(global.process.env.SENTRY_AUTH_TOKEN) && [
-        '@sentry/react-native',
         '@sentry/react-native/expo',
         {
           project: 'ef-app_react-native',

--- a/app.config.js
+++ b/app.config.js
@@ -45,8 +45,6 @@ module.exports = {
       package: 'org.eurofurence.connavigator',
       icon: './assets/platform/appicon-android.png',
       googleServicesFile: './assets/platform/google-services.json',
-      targetSdkVersion: 36,
-      compileSdkVersion: 36,
       newArchEnabled: true,
       splash: {
         resizeMode: 'native',
@@ -144,9 +142,9 @@ module.exports = {
             privacyManifestAggregationEnabled: true,
           },
           android: {
-            compileSdkVersion: 35,
-            targetSdkVersion: 35,
-            buildToolsVersion: '35.0.0',
+            compileSdkVersion: 36,
+            targetSdkVersion: 36,
+            buildToolsVersion: '36.0.0',
           },
         },
       ],


### PR DESCRIPTION
Fixes an issue that, when sentry auth token is defined, causes a build crash due to plugin array not aligning with expo app config types.