### PR TITLE
Add Calendar Sync within user settings

### DIFF
--- a/src/components/settings/CalendarSync.tsx
+++ b/src/components/settings/CalendarSync.tsx
@@ -1,0 +1,118 @@
+import { captureException } from '@sentry/react-native'
+import { setStringAsync } from 'expo-clipboard'
+import { useTranslation } from 'react-i18next'
+import { Linking, StyleSheet } from 'react-native'
+import { Icon } from '@/components/generic/atoms/Icon'
+import { Section } from '@/components/generic/atoms/Section'
+import { Button, buttonIconSize } from '@/components/generic/containers/Button'
+import { Row } from '@/components/generic/containers/Row'
+import { Pressable } from '@/components/generic/Pressable'
+import { apiBase } from '@/configuration'
+import { useAuthContext } from '@/context/auth/Auth'
+import { useToastContext } from '@/context/ui/ToastContext'
+import { useFavoritesCalendarToken } from '@/hooks/api/events/useFavoritesCalendarToken'
+import {
+  useThemeBorder,
+  useThemeColorValue,
+} from '@/hooks/themes/useThemeHooks'
+
+import { SettingContainer } from './SettingContainer'
+
+export const CalendarSync = () => {
+  const { t } = useTranslation('Settings', { keyPrefix: 'calendar' })
+  const { loggedIn } = useAuthContext()
+  const { toast } = useToastContext()
+  const {
+    data: token,
+    isLoading,
+    isError,
+    refetch,
+  } = useFavoritesCalendarToken()
+
+  // Match the outline button's look for the icon-only copy affordance.
+  const copyBorder = useThemeBorder('inverted')
+  const copyColor = useThemeColorValue('important')
+
+  // The feed is keyed to a per-user token, so it only exists when signed in.
+  if (!loggedIn) return null
+
+  const feedUrl = token
+    ? `${apiBase}/Events/Favorites/calendar.ics/?token=${encodeURIComponent(token)}`
+    : null
+
+  // Convert to webcal scheme that lets the OS calendar subscribe to it for polling.
+  const webcalUrl = feedUrl
+    ? feedUrl.replace(/^https?:\/\//, 'webcal://')
+    : null
+
+  const onError = (error: unknown) => {
+    captureException(error)
+    toast('error', t('error'), 5000)
+  }
+
+  const onSubscribe = () => {
+    if (!webcalUrl) return
+    Linking.openURL(webcalUrl).catch(onError)
+  }
+
+  const onCopy = () => {
+    if (!feedUrl) return
+    setStringAsync(feedUrl)
+      .then(() => toast('info', t('link_copied'), 3000))
+      .catch(onError)
+  }
+
+  const subscribeDisabled = isLoading || !webcalUrl
+  const copyDisabled = isLoading || !feedUrl
+
+  return (
+    <SettingContainer>
+      <Section
+        title={t('title')}
+        subtitle={t('subtitle')}
+        icon='calendar-sync'
+      />
+
+      {isError ? (
+        <Button icon='refresh' onPress={() => refetch()}>
+          {t('retry')}
+        </Button>
+      ) : (
+        <Row type='stretch' gap={10}>
+          <Button
+            containerStyle={styles.subscribe}
+            icon='calendar-export'
+            onPress={onSubscribe}
+            disabled={subscribeDisabled}
+          >
+            {t('subscribe')}
+          </Button>
+          <Pressable
+            style={[styles.copy, copyBorder, copyDisabled && styles.disabled]}
+            onPress={onCopy}
+            disabled={copyDisabled}
+            accessibilityLabel={t('copy_link')}
+          >
+            <Icon name='content-copy' size={buttonIconSize} color={copyColor} />
+          </Pressable>
+        </Row>
+      )}
+    </SettingContainer>
+  )
+}
+
+const styles = StyleSheet.create({
+  subscribe: {
+    flex: 1,
+  },
+  copy: {
+    aspectRatio: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 16,
+    borderWidth: 2,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+})

--- a/src/components/settings/CalendarSync.tsx
+++ b/src/components/settings/CalendarSync.tsx
@@ -3,6 +3,7 @@ import { setStringAsync } from 'expo-clipboard'
 import { useTranslation } from 'react-i18next'
 import { Linking, StyleSheet } from 'react-native'
 import { Icon } from '@/components/generic/atoms/Icon'
+import { Label } from '@/components/generic/atoms/Label'
 import { Section } from '@/components/generic/atoms/Section'
 import { Button, buttonIconSize } from '@/components/generic/containers/Button'
 import { Row } from '@/components/generic/containers/Row'
@@ -32,9 +33,6 @@ export const CalendarSync = () => {
   // Match the outline button's look for the icon-only copy affordance.
   const copyBorder = useThemeBorder('inverted')
   const copyColor = useThemeColorValue('important')
-
-  // The feed is keyed to a per-user token, so it only exists when signed in.
-  if (!loggedIn) return null
 
   const feedUrl = token
     ? `${apiBase}/Events/Favorites/calendar.ics/?token=${encodeURIComponent(token)}`
@@ -73,7 +71,20 @@ export const CalendarSync = () => {
         icon='calendar-sync'
       />
 
-      {isError ? (
+      {!loggedIn ? (
+        <>
+          <Label variant='narrow' style={styles.hint}>
+            {t('login_required')}
+          </Label>
+          <Button
+            icon='calendar-export'
+            disabled
+            accessibilityHint={t('login_required')}
+          >
+            {t('subscribe')}
+          </Button>
+        </>
+      ) : isError ? (
         <Button icon='refresh' onPress={() => refetch()}>
           {t('retry')}
         </Button>
@@ -102,6 +113,9 @@ export const CalendarSync = () => {
 }
 
 const styles = StyleSheet.create({
+  hint: {
+    marginBottom: 10,
+  },
   subscribe: {
     flex: 1,
   },

--- a/src/components/settings/UserSettings.tsx
+++ b/src/components/settings/UserSettings.tsx
@@ -7,6 +7,7 @@ import { useCache } from '@/context/data/Cache'
 import { vibrateAfter } from '@/util/vibrateAfter'
 
 import { AnalyticsOptIns } from './AnalyticsOptIns'
+import { CalendarSync } from './CalendarSync'
 import { HiddenEvents } from './HiddenEvents'
 import { LanguagePicker } from './LanguagePicker'
 import { ThemePicker } from './ThemePicker'
@@ -35,6 +36,9 @@ export function UserSettings() {
 
       {/* Warning settings */}
       <Warnings />
+
+      {/* Subscribe favorite events to the device calendar */}
+      <CalendarSync />
 
       {/* Force full sync (fetch all data) */}
       <Button

--- a/src/hooks/api/events/useFavoritesCalendarToken.ts
+++ b/src/hooks/api/events/useFavoritesCalendarToken.ts
@@ -1,0 +1,36 @@
+import {
+  type QueryFunctionContext,
+  type UseQueryResult,
+  useQuery,
+} from '@tanstack/react-query'
+import axios, { type GenericAbortSignal } from 'axios'
+import { apiBase } from '@/configuration'
+import { useAuthContext } from '@/context/auth/Auth'
+
+async function getFavoritesCalendarToken(
+  accessToken: string | null,
+  signal?: GenericAbortSignal
+) {
+  if (!accessToken) throw new Error('Unauthorized')
+
+  return await axios
+    .get(`${apiBase}/Events/Favorites/:calendar-token`, {
+      signal: signal,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    .then((res) => res.data as string)
+}
+
+export function useFavoritesCalendarToken(): UseQueryResult<string | null> {
+  const { accessToken, idData, loggedIn } = useAuthContext()
+
+  return useQuery({
+    queryKey: [idData?.sub, 'favorites-calendar-token'],
+    queryFn: (context: QueryFunctionContext) =>
+      getFavoritesCalendarToken(accessToken, context.signal),
+    enabled: loggedIn,
+    retry: false,
+  })
+}

--- a/src/i18n/translations.de.json
+++ b/src/i18n/translations.de.json
@@ -804,6 +804,7 @@
       "copy_link": "Kalenderlink kopieren",
       "error": "Kalender konnte nicht geöffnet werden. Kopiere stattdessen den Link.",
       "link_copied": "Kalenderlink in die Zwischenablage kopiert",
+      "login_required": "Melde Dich an, um Deine Favoriten zu synchronisieren.",
       "retry": "Erneut versuchen",
       "subscribe": "Favoriten zum Kalender hinzufügen",
       "subtitle": "Abonniere Deine Favoriten mit Deiner Kalender-App. Neue Favoriten und Änderungen werden automatisch synchronisiert.",

--- a/src/i18n/translations.de.json
+++ b/src/i18n/translations.de.json
@@ -800,6 +800,15 @@
       "synchronize": "Synchronisieren",
       "title": "Cache-Statistiken"
     },
+    "calendar": {
+      "copy_link": "Kalenderlink kopieren",
+      "error": "Kalender konnte nicht geöffnet werden. Kopiere stattdessen den Link.",
+      "link_copied": "Kalenderlink in die Zwischenablage kopiert",
+      "retry": "Erneut versuchen",
+      "subscribe": "Favoriten zum Kalender hinzufügen",
+      "subtitle": "Abonniere Deine Favoriten mit Deiner Kalender-App. Neue Favoriten und Änderungen werden automatisch synchronisiert.",
+      "title": "Kalender-Synchronisierung"
+    },
     "changeLanguage": "Sprache ändern",
     "currentLanguage": "Deine Sprachauswahl ist Deutsch!",
     "developer_settings": {

--- a/src/i18n/translations.en.json
+++ b/src/i18n/translations.en.json
@@ -817,6 +817,15 @@
       "synchronize": "Synchronize",
       "title": "Cache Stats"
     },
+    "calendar": {
+      "copy_link": "Copy calendar link",
+      "error": "Could not open your calendar. Try copying the link instead.",
+      "link_copied": "Calendar link copied to clipboard",
+      "retry": "Try again",
+      "subscribe": "Add favorites to calendar",
+      "subtitle": "Subscribe your calendar app to your favorite events. New favorites and changes sync automatically.",
+      "title": "Calendar sync"
+    },
     "changeLanguage": "Change language",
     "currentLanguage": "Your current language is English!",
     "dev_buttons": {

--- a/src/i18n/translations.en.json
+++ b/src/i18n/translations.en.json
@@ -821,6 +821,7 @@
       "copy_link": "Copy calendar link",
       "error": "Could not open your calendar. Try copying the link instead.",
       "link_copied": "Calendar link copied to clipboard",
+      "login_required": "Log in to sync your favorite events.",
       "retry": "Try again",
       "subscribe": "Add favorites to calendar",
       "subtitle": "Subscribe your calendar app to your favorite events. New favorites and changes sync automatically.",

--- a/src/i18n/translations.nl.json
+++ b/src/i18n/translations.nl.json
@@ -664,6 +664,15 @@
       "synchronize": "Synchronizeer",
       "title": "Opslagstatus"
     },
+    "calendar": {
+      "copy_link": "Kalenderlink kopiëren",
+      "error": "Kan de kalender niet openen. Kopieer in plaats daarvan de link.",
+      "link_copied": "Kalenderlink gekopieerd naar klembord",
+      "retry": "Probeer opnieuw",
+      "subscribe": "Favorieten aan kalender toevoegen",
+      "subtitle": "Abonneer je kalender-app op je favoriete evenementen. Nieuwe favorieten en wijzigingen worden automatisch gesynchroniseerd.",
+      "title": "Kalendersynchronisatie"
+    },
     "changeLanguage": "Verander taal",
     "currentLanguage": "Jouw huidige taal is Nederlands!",
     "developer_settings": {

--- a/src/i18n/translations.nl.json
+++ b/src/i18n/translations.nl.json
@@ -668,6 +668,7 @@
       "copy_link": "Kalenderlink kopiëren",
       "error": "Kan de kalender niet openen. Kopieer in plaats daarvan de link.",
       "link_copied": "Kalenderlink gekopieerd naar klembord",
+      "login_required": "Meld je aan om je favoriete evenementen te synchroniseren.",
       "retry": "Probeer opnieuw",
       "subscribe": "Favorieten aan kalender toevoegen",
       "subtitle": "Abonneer je kalender-app op je favoriete evenementen. Nieuwe favorieten en wijzigingen worden automatisch gesynchroniseerd.",


### PR DESCRIPTION
Adds a calendar sync section to user settings that allows subscribing device calendar to user's favorite events.

- Uses `webcall://` subscription format, handled by the OS.
- Fallback to copying URL.

Part of #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar sync in Settings so users can subscribe to their favorites calendar feed.
  * Added quick actions to copy the calendar link or open it directly in the device calendar app.
  * Added localized calendar sync text in English, German, and Dutch.

* **Bug Fixes**
  * Improved logged-out and error states with clearer prompts to retry, sign in, or copy the link instead.
  * Added feedback for successful copies and calendar-opening errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->