### PR TITLE
Fix sticky section headers on the Info Articles list

### DIFF
--- a/src/app/knowledge/index.tsx
+++ b/src/app/knowledge/index.tsx
@@ -149,17 +149,20 @@ export default function Knowledge() {
         accessibilityHint={t('accessibility.kb_sectioned_list_hint')}
       >
         <Header>{t('header')}</Header>
-        <KbSectionedList
-          kbGroups={displayData}
-          leader={
-            <Search
-              className='my-2.5 mx-2.5'
-              filter={filter}
-              setFilter={setFilter}
-              placeholder={t('search.placeholder')}
-            />
-          }
-        />
+        {/* flex allows sticky sections to stick correctly under the header */}
+        <View className='flex-1'>
+          <KbSectionedList
+            kbGroups={displayData}
+            leader={
+              <Search
+                className='my-2.5 mx-2.5'
+                filter={filter}
+                setFilter={setFilter}
+                placeholder={t('search.placeholder')}
+              />
+            }
+          />
+        </View>
       </View>
     </>
   )


### PR DESCRIPTION
Fixes mispositioned sticky headers in the Info Articles page by wrapping it via `flex-1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Knowledge screen layout so section headers stick correctly beneath the top header while scrolling.
  * Updated the screen structure to better support the search and content list display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->