### PR TITLE
Make WiFi-QR scan cancelable with button

### DIFF
--- a/src/app/wifi/scan.tsx
+++ b/src/app/wifi/scan.tsx
@@ -28,23 +28,45 @@ export default function WifiScanScreen() {
   if (!permission) return <View />
   if (!permission.granted) {
     return (
-      <View style={styles.center}>
-        <Label type='para' className='mb-4'>
-          {t('camera_permission')}
-        </Label>
-        <Button icon='camera' onPress={requestPermission}>
-          {t('grant_camera')}
-        </Button>
-      </View>
+      <>
+        <View style={styles.center}>
+          <Label type='para' className='mb-4'>
+            {t('camera_permission')}
+          </Label>
+          <Button icon='camera' onPress={requestPermission}>
+            {t('grant_camera')}
+          </Button>
+        </View>
+        <View style={styles.bottom}>
+          <Button
+            style={styles.back}
+            icon='arrow-left'
+            onPress={() => router.replace({ pathname: '/wifi' })}
+          >
+            {t('confirm_cancel')}
+          </Button>
+        </View>
+      </>
     )
   }
 
   return (
-    <CameraView
-      style={StyleSheet.absoluteFill}
-      barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
-      onBarcodeScanned={onScanned}
-    />
+    <>
+      <CameraView
+        style={StyleSheet.absoluteFill}
+        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+        onBarcodeScanned={onScanned}
+      />
+      <View style={styles.bottom}>
+        <Button
+          style={styles.back}
+          icon='arrow-left'
+          onPress={() => router.replace({ pathname: '/wifi' })}
+        >
+          {t('confirm_cancel')}
+        </Button>
+      </View>
+    </>
   )
 }
 
@@ -54,5 +76,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 24,
+  },
+  bottom: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    padding: 8,
+    width: '100%',
+  },
+  back: {
+    width: '100%',
   },
 })


### PR DESCRIPTION
Added button as requested in DM talks with Faye.

Result:
Users can now cancel out of the camera view via a button at the bottom and don't rely on system navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a consistent bottom “Back” button to the Wi‑Fi scanning screen.
  * The button now appears whether camera permission is granted or denied.
  * Improved layout positioning so the button remains bottom-aligned alongside the permission prompt or camera view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->