### PR TITLE
fix: double share links

### DIFF
--- a/src/components/dealers/Dealers.common.ts
+++ b/src/components/dealers/Dealers.common.ts
@@ -1,10 +1,8 @@
-import { captureException } from '@sentry/react-native'
 import { format, setDay } from 'date-fns'
 import { router } from 'expo-router'
 import type { TFunction } from 'i18next'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Share } from 'react-native'
 
 import {
   type DealerDetailsInstance,
@@ -16,10 +14,11 @@ import {
   dealerSectionForLetter,
   dealerSectionForLocation,
 } from '@/components/dealers/DealerSection'
-import { appBase, conAbbr } from '@/configuration'
+import { appBase } from '@/configuration'
 import { useCache } from '@/context/data/Cache'
 import type { DealerDetails } from '@/context/data/types.details'
 import { useToastContext } from '@/context/ui/ToastContext'
+import { shareLink } from '@/util/shareLink'
 
 /**
  * Compares category, checks if the categories are adult labeled.
@@ -175,17 +174,12 @@ export const useDealerAlphabeticalGroups = (
 }
 
 export const shareDealer = (dealer: DealerDetails) =>
-  Share.share(
-    {
-      title:
-        dealer.DisplayNameOrAttendeeNickname ||
-        dealer.DisplayName ||
-        'Unknown Dealer',
-      url: `${appBase}/Web/Dealers/${dealer.Id}`,
-      message: `Check out ${dealer.DisplayNameOrAttendeeNickname || dealer.DisplayName || 'Unknown Dealer'} on ${conAbbr}!\n${appBase}/Web/Dealers/${dealer.Id}`,
-    },
-    {}
-  ).catch(captureException)
+  shareLink(
+    dealer.DisplayNameOrAttendeeNickname ||
+      dealer.DisplayName ||
+      'Unknown Dealer',
+    `${appBase}/Web/Dealers/${dealer.Id}`
+  )
 
 /**
  * Returns a function that toggles dealer favorite state.

--- a/src/components/events/Events.common.ts
+++ b/src/components/events/Events.common.ts
@@ -4,7 +4,6 @@ import { router } from 'expo-router'
 import type { TFunction } from 'i18next'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Share } from 'react-native'
 
 import {
   type EventDetailsInstance,
@@ -19,10 +18,11 @@ import {
   eventSectionForPartOfDay,
   eventSectionForPassed,
 } from '@/components/events/EventSection'
-import { appBase, conAbbr } from '@/configuration'
+import { appBase } from '@/configuration'
 import type { EventDetails } from '@/context/data/types.details'
 import { useToastContext } from '@/context/ui/ToastContext'
 import { useToggleEventFavorite } from '@/hooks/data/useToggleEventFavorite'
+import { shareLink } from '@/util/shareLink'
 
 /**
  Returns a list of event instances according to conversion rules.
@@ -194,14 +194,7 @@ export const useEventOtherGroups = (
 }
 
 export const shareEvent = (event: EventDetails) =>
-  Share.share(
-    {
-      title: event.Title,
-      url: `${appBase}/Web/Events/${event.Id}`,
-      message: `Check out ${event.Title} on ${conAbbr}!\n${appBase}/Web/Events/${event.Id}`,
-    },
-    {}
-  ).catch(captureException)
+  shareLink(event.Title, `${appBase}/Web/Events/${event.Id}`)
 
 /**
  * Uses default handlers for event card interaction, i.e., opening the event or toggling favorites.

--- a/src/components/images/Images.common.ts
+++ b/src/components/images/Images.common.ts
@@ -1,17 +1,8 @@
-import { captureException } from '@sentry/react-native'
-import { Dimensions, Share } from 'react-native'
+import { Dimensions } from 'react-native'
 
-import { conAbbr } from '@/configuration'
+import { shareLink } from '@/util/shareLink'
 
-export const shareImage = (url: string, title: string) =>
-  Share.share(
-    {
-      title,
-      url,
-      message: `Check out ${title} on ${conAbbr}!\n${url}`,
-    },
-    {}
-  ).catch(captureException)
+export const shareImage = (url: string, title: string) => shareLink(title, url)
 
 export const minZoomFor = (width: number, height: number, padding: number) => {
   if (width <= 0 || height <= 0) return 1

--- a/src/util/shareLink.ts
+++ b/src/util/shareLink.ts
@@ -1,0 +1,19 @@
+import { captureException } from '@sentry/react-native'
+import { Platform, Share } from 'react-native'
+
+import { conAbbr } from '@/configuration'
+
+/**
+ * Shares a titled link. Android's share sheet ignores the `url` field, so the
+ * link has to be inlined into the message there; on the other platforms it is
+ * passed separately to keep the preview rich and avoid printing it twice.
+ */
+export const shareLink = (title: string, url: string) => {
+  const message = `Check out ${title} on ${conAbbr}!`
+  return Share.share(
+    Platform.OS === 'android'
+      ? { title, message: `${message}\n${url}` }
+      : { title, message, url },
+    {}
+  ).catch(captureException)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent link sharing for dealers, events, and images.
  * Sharing now includes the relevant title and link across platforms.
  * Improved Android sharing by including the link directly in the shared message.

* **Bug Fixes**
  * Improved error tracking when link sharing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->