### PR TITLE
hotfix: Change IOS WiFi preload urls to static files

### DIFF
--- a/src/components/wifi/WifiSetup.tsx
+++ b/src/components/wifi/WifiSetup.tsx
@@ -13,7 +13,7 @@ import { ManagedTextInput } from '@/components/generic/forms/ManagedTextInput'
 import { addEnterpriseNetwork } from '@/components/wifi/efWifiModule'
 import {
   buildOnsiteFileUrl,
-  buildOnsiteProfileUrl,
+  buildOnsiteFileUrlCustom,
   credentialsForProfile,
   WIFI_ANONYMOUS_IDENTITY,
   WIFI_DOMAIN_SUFFIX_MATCH,
@@ -99,7 +99,7 @@ export function WifiSetup({
         // custom creds can't be static, so they open the prefilled onsite page (tap Download there).
         const url =
           profile === 'custom'
-            ? buildOnsiteProfileUrl(creds.identity, creds.password)
+            ? buildOnsiteFileUrlCustom(creds.identity, creds.password)
             : buildOnsiteFileUrl(profile)
         await Linking.openURL(url)
       }

--- a/src/components/wifi/wifi.common.ts
+++ b/src/components/wifi/wifi.common.ts
@@ -100,10 +100,19 @@ export function buildOnsiteProfileUrl(
 /**
  * Build a DIRECT URL to a pre-filled, statically-hosted .mobileconfig for a PUBLIC profile.
  * Opening it in Safari triggers the iOS install prompt in one step (no tutorial-page tap).
- * Custom credentials can't be static, so those use buildOnsiteProfileUrl (the prefilled page).
+ * buildOnsiteFileUrl       -> general profiles
+ * buildOnsiteFileUrlCustom -> custom profiles with preloaded credentials
  */
 export function buildOnsiteFileUrl(
   profile: (typeof WIFI_PUBLIC_PROFILE_IDS)[number]
 ): string {
   return `${WIFI_ONSITE_URL}/ios-profile-${profile}/`
+}
+
+export function buildOnsiteFileUrlCustom(
+  identity: string,
+  password: string
+): string {
+  const params = new URLSearchParams({ id: identity, pw: password })
+  return `${WIFI_ONSITE_URL}/ios-profile-custom/?${params.toString()}`
 }


### PR DESCRIPTION
fully automate staffnet logon on IOS, don't stop by on the website

change effective: "configure wifi" lands on https://wifi.onsite.eurofurence.org/ios-profile-custom/?id=XXX&pw=YYY instead of https://wifi.onsite.eurofurence.org/?id=XXX&pw=YYY